### PR TITLE
Fix http external repositories.

### DIFF
--- a/integrations/bdi-matsim/pom.xml
+++ b/integrations/bdi-matsim/pom.xml
@@ -23,7 +23,7 @@
                 </repository>
                 <repository>
                         <id>matsim</id>
-                        <url>http://dl.bintray.com/matsim/matsim</url>
+                        <url>https://dl.bintray.com/matsim/matsim</url>
                 </repository>
                 <repository>
                         <!-- For MATSim monthly snapshots: -->
@@ -33,7 +33,7 @@
                 </repository>
                 <repository>
                         <id>ojo-snapshots</id>
-                        <url>http://oss.jfrog.org/libs-snapshot</url>
+                        <url>https://oss.jfrog.org/libs-snapshot</url>
                 </repository>
         </repositories>
 

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -25,11 +25,11 @@
 		</repository>
 		<repository>
 			<id>matsim</id>
-			<url>http://dl.bintray.com/matsim/matsim</url>
+			<url>https://dl.bintray.com/matsim/matsim</url>
 		</repository>
 		<repository>
 			<id>ojo-snapshots</id>
-			<url>http://oss.jfrog.org/libs-snapshot</url>
+			<url>https://oss.jfrog.org/libs-snapshot</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
[Maven 3.8.1](https://maven.apache.org/docs/3.8.1/release-notes.html) requires external repositories to be https.


